### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function (data, options) {
 		}
 
 		try {
-			file.contents = new Buffer(template(file.contents.toString(), data, options));
+			file.contents = new Buffer(template(file.contents).toString(), data, options);
 			cb(null, file);
 		} catch (err) {
 			cb(new gutil.PluginError('gulp-template', err, {fileName: file.path}));


### PR DESCRIPTION
I was running into a bug where templates were not processing, throwing the error 
"TypeError: First argument needs to be a number, array or string at new Buffer." 

By moving the parens around, I got it to work.
