### PR TITLE
Fix gulp-data support

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,12 +30,14 @@ function compile(options, getData) {
 }
 
 module.exports = function (data, options) {
-	return compile(options, function(file) {
-		if (file.data) {
-			data = _.merge(file.data, data);
-		}
+	return compile(options, function (file) {
+		return function (data) {
+			if (file.data) {
+				data = _.merge({}, file.data, data);
+			}
 
-		return data || {};
+			return data || {};
+		}(data);
 	});
 };
 

--- a/index.js
+++ b/index.js
@@ -31,13 +31,7 @@ function compile(options, getData) {
 
 module.exports = function (data, options) {
 	return compile(options, function (file) {
-		return function (data) {
-			if (file.data) {
-				data = _.merge({}, file.data, data);
-			}
-
-			return data || {};
-		}(data);
+		return _.merge({}, file.data, data);
 	});
 };
 

--- a/test.js
+++ b/test.js
@@ -97,6 +97,44 @@ it('should merge gulp-data and data parameter', function (cb) {
 	stream.end();
 });
 
+it('should not alter gulp-data or data parameter', function (cb) {
+	var chunks = [];
+
+	var stream = data(function (file) {
+		return {
+			contents: file.contents.toString()
+		};
+	});
+
+	var parameter = {
+		foo: 'foo',
+		bar: 'bar',
+		foobar: ['foo', 'bar']
+	};
+
+	stream.pipe(template(parameter));
+
+	stream.on('data', function (chunk) {
+		chunks.push(chunk);
+	});
+
+	stream.on('end', function () {
+		assert.deepEqual(chunks[0].data, {contents: 'foo'});
+		assert.deepEqual(parameter, {
+			foo: 'foo',
+			bar: 'bar',
+			foobar: ['foo', 'bar']
+		});
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		contents: new Buffer('foo')
+	}));
+
+	stream.end();
+});
+
 it('should work with no data supplied', function (cb) {
 	var stream = template();
 

--- a/test.js
+++ b/test.js
@@ -21,22 +21,34 @@ it('should compile Lodash templates', function (cb) {
 });
 
 it('should support data via gulp-data', function (cb) {
-	var stream = data(function () {
+	var dl = [];
+
+	var stream = data(function (file) {
 		return {
-			people: ['foo', 'bar']
+			dd: file.path
 		};
 	});
 
-	stream.pipe(template());
+	stream.pipe(template({dt: 'path'}));
 
-	stream.on('data', function (data) {
-		assert.equal(data.contents.toString(), '<li>foo</li><li>bar</li>');
+	stream.on('data', function (chunk) {
+		dl.push(chunk.contents.toString());
 	});
 
-	stream.on('end', cb);
+	stream.on('end', function () {
+		var expected = '<dt>path</dt><dd>bar.txt</dd><dt>path</dt><dd>foo.txt</dd>';
+		assert.equal(dl.sort().join(''), expected);
+		cb();
+	});
 
 	stream.write(new gutil.File({
-		contents: new Buffer('<% _.forEach(people, function (name) { %><li><%- name %></li><% }); %>')
+		path: 'foo.txt',
+		contents: new Buffer('<dt><%- dt %></dt><dd><%- dd %></dd>')
+	}));
+
+	stream.write(new gutil.File({
+		path: 'bar.txt',
+		contents: new Buffer('<dt><%- dt %></dt><dd><%- dd %></dd>')
 	}));
 
 	stream.end();
@@ -46,26 +58,38 @@ it('should support Lo-Dash options with gulp-data', function (cb) {
 	var options = {
 		variable: 'data',
 		imports: {
-			heading: 'people'
+			dt: 'path'
 		}
 	};
 
-	var stream = data(function () {
+	var dl = [];
+
+	var stream = data(function (file) {
 		return {
-			people: ['foo', 'bar']
+			dd: file.path
 		};
 	});
 
 	stream.pipe(template(null, options));
 
-	stream.on('data', function (data) {
-		assert.equal(data.contents.toString(), '<h1>people</h1><li>foo</li><li>bar</li>');
+	stream.on('data', function (chunk) {
+		dl.push(chunk.contents.toString());
 	});
 
-	stream.on('end', cb);
+	stream.on('end', function () {
+		var expected = '<dt>path</dt><dd>bar.txt</dd><dt>path</dt><dd>foo.txt</dd>';
+		assert.equal(dl.sort().join(''), expected);
+		cb();
+	});
 
 	stream.write(new gutil.File({
-		contents: new Buffer('<h1><%= heading %></h1><% _.forEach(data.people, function (name) { %><li><%- name %></li><% }); %>')
+		path: 'foo.txt',
+		contents: new Buffer('<dt><%- dt %></dt><dd><%- data.dd %></dd>')
+	}));
+
+	stream.write(new gutil.File({
+		path: 'bar.txt',
+		contents: new Buffer('<dt><%- dt %></dt><dd><%- data.dd %></dd>')
 	}));
 
 	stream.end();


### PR DESCRIPTION
Hello,

The issue is best described by the updated test “should support data via gulp-data”.
Without the fix it fails with:
```
Uncaught AssertionError: "<dt>path</dt><dd>foo.txt</dd><dt>path</dt><dd>foo.txt</dd>" == "<dt>path</dt><dd>bar.txt</dd><dt>path</dt><dd>foo.txt</dd>"
```

This is because _.template’s data parameter is altered each time a chunk is processed.