### PR TITLE
Splits lodash dependency into used functions only

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 var gutil = require('gulp-util');
 var through = require('through2');
-var _ = require('lodash');
-var template = _.template;
+var template = require('lodash.template');
+var merge = require('lodash.merge');
 
 function compile(options, data, render) {
 	return through.obj(function (file, enc, cb) {
@@ -18,7 +18,7 @@ function compile(options, data, render) {
 
 		try {
 			var tpl = template(file.contents.toString(), options);
-			file.contents = new Buffer(render ? tpl(_.merge({}, file.data, data)) : tpl.toString());
+			file.contents = new Buffer(render ? tpl(merge({}, file.data, data)) : tpl.toString());
 			this.push(file);
 		} catch (err) {
 			this.emit('error', new gutil.PluginError('gulp-template', err, {fileName: file.path}));

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "lodash": "^4.8.2",
+    "lodash.merge": "^4.5.1",
+    "lodash.template": "^4.3.0",
     "through2": "^2.0.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -15,7 +15,7 @@ it('should compile Lodash templates', function (cb) {
 	stream.on('end', cb);
 
 	stream.write(new gutil.File({
-		contents: new Buffer('<% _.forEach(people, function (name) { %><li><%- name %></li><% }); %>')
+		contents: new Buffer('<% people.forEach(function (name) { %><li><%- name %></li><% }); %>')
 	}));
 
 	stream.end();
@@ -122,7 +122,7 @@ it('should merge gulp-data and data parameter', function (cb) {
 	stream.on('end', cb);
 
 	stream.write(new gutil.File({
-		contents: new Buffer('<h1><%= heading %></h1><% _.forEach(people, function (name) { %><li><%- name %></li><% }); %><%= nested.a %>,<%= nested.b %>,<%= nested.c %>')
+		contents: new Buffer('<h1><%= heading %></h1><% people.forEach(function (name) { %><li><%- name %></li><% }); %><%= nested.a %>,<%= nested.b %>,<%= nested.c %>')
 	}));
 
 	stream.end();


### PR DESCRIPTION
Hey everyone, thanks for the amazing work done here.

I was looking at this project to try to do something similar with another open source project that I'm working on with my friends, but without `gulp`.

I noticed that you guys are requiring all `lodash` library, and I saw that it's possible to define just specific parts of `lodash` as `npm` dependencies, instead of the whole library...

So I replaced `lodash` dependency by `lodash.merge` and `lodash.template`, it seems it's all that this project needs. (I didn't add `lodash.foreach` though).

I'm not sure if I'm correct about this, or if you guys want this, it was just a thought of mine :)

EDIT:
From `4.7M` of `lodash` dependencies, we got `396K` with this change.