### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+package-lock.json
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var through = require('through2');
 var _ = require('lodash');
 var template = _.template;
@@ -12,7 +12,7 @@ function compile(options, data, render) {
 		}
 
 		if (file.isStream()) {
-			cb(new gutil.PluginError('gulp-template', 'Streaming not supported'));
+			cb(new PluginError('gulp-template', 'Streaming not supported'));
 			return;
 		}
 
@@ -21,7 +21,7 @@ function compile(options, data, render) {
 			file.contents = new Buffer(render ? tpl(_.merge({}, file.data, data)) : tpl.toString());
 			this.push(file);
 		} catch (err) {
-			this.emit('error', new gutil.PluginError('gulp-template', err, {fileName: file.path}));
+			this.emit('error', new PluginError('gulp-template', err, {fileName: file.path}));
 		}
 
 		cb();

--- a/package.json
+++ b/package.json
@@ -32,11 +32,13 @@
   "dependencies": {
     "gulp-util": "^3.0.0",
     "lodash": "^4.8.2",
+    "plugin-error": "^0.1.2",
     "through2": "^2.0.0"
   },
   "devDependencies": {
     "gulp-data": "^1.0.2",
     "mocha": "*",
+    "vinyl": "^2.1.0",
     "xo": "*"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 'use strict';
 /* eslint-env mocha */
 var assert = require('assert');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var data = require('gulp-data');
 var template = require('./');
 
@@ -14,7 +14,7 @@ it('should compile Lodash templates', function (cb) {
 
 	stream.on('end', cb);
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		contents: new Buffer('<% _.forEach(people, function (name) { %><li><%- name %></li><% }); %>')
 	}));
 
@@ -42,12 +42,12 @@ it('should support data via gulp-data', function (cb) {
 		cb();
 	});
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		path: 'foo.txt',
 		contents: new Buffer('<dt><%- dt %></dt><dd><%- dd %></dd>')
 	}));
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		path: 'bar.txt',
 		contents: new Buffer('<dt><%- dt %></dt><dd><%- dd %></dd>')
 	}));
@@ -83,12 +83,12 @@ it('should support Lo-Dash options with gulp-data', function (cb) {
 		cb();
 	});
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		path: 'foo.txt',
 		contents: new Buffer('<dt><%- dt %></dt><dd><%- data.dd %></dd>')
 	}));
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		path: 'bar.txt',
 		contents: new Buffer('<dt><%- dt %></dt><dd><%- data.dd %></dd>')
 	}));
@@ -121,7 +121,7 @@ it('should merge gulp-data and data parameter', function (cb) {
 
 	stream.on('end', cb);
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		contents: new Buffer('<h1><%= heading %></h1><% _.forEach(people, function (name) { %><li><%- name %></li><% }); %><%= nested.a %>,<%= nested.b %>,<%= nested.c %>')
 	}));
 
@@ -159,7 +159,7 @@ it('should not alter gulp-data or data parameter', function (cb) {
 		cb();
 	});
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		contents: new Buffer('foo')
 	}));
 
@@ -175,7 +175,7 @@ it('should work with no data supplied', function (cb) {
 
 	stream.on('end', cb);
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		contents: new Buffer('')
 	}));
 
@@ -191,7 +191,7 @@ it('should precompile Lodash templates', function (cb) {
 
 	stream.on('end', cb);
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		contents: new Buffer('<h1><%= heading %></h1>')
 	}));
 
@@ -211,7 +211,7 @@ it('should support Lo-Dash options when precompiling', function (cb) {
 
 	stream.on('end', cb);
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		contents: new Buffer('<h1><%= heading %></h1>')
 	}));
 


### PR DESCRIPTION
Closes sindresorhus/gulp-template#41